### PR TITLE
UD-36 feature/post-disagreement

### DIFF
--- a/src/main/java/likelion/underdog/songgotmae/domain/agreement/Agreement.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/agreement/Agreement.java
@@ -42,21 +42,15 @@ public class Agreement {
     @Column(nullable = false)
     private LocalDateTime modifiedAt;
 
-    private Long agreementCount;
-    private Long disagreementCount;
 
-    public void updateAgreementCounts(long agreementCount, long disagreementCount) {
-        if (isAgree) {
-            this.agreementCount = agreementCount;
-        } else {
-            this.disagreementCount = disagreementCount;
-        }
-    }
 
     @Builder
     public Agreement(Member member, Post post, Boolean isAgree) {
         this.member = member;
         this.post = post;
         this.isAgree = isAgree;
+    }
+
+    public void updateAgreementCounts(long agreementCount, long disagreementCount) {
     }
 }

--- a/src/main/java/likelion/underdog/songgotmae/domain/agreement/Agreement.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/agreement/Agreement.java
@@ -42,6 +42,17 @@ public class Agreement {
     @Column(nullable = false)
     private LocalDateTime modifiedAt;
 
+    private Long agreementCount;
+    private Long disagreementCount;
+
+    public void updateAgreementCounts(long agreementCount, long disagreementCount) {
+        if (isAgree) {
+            this.agreementCount = agreementCount;
+        } else {
+            this.disagreementCount = disagreementCount;
+        }
+    }
+
     @Builder
     public Agreement(Member member, Post post, Boolean isAgree) {
         this.member = member;

--- a/src/main/java/likelion/underdog/songgotmae/domain/agreement/Agreement.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/agreement/Agreement.java
@@ -51,6 +51,5 @@ public class Agreement {
         this.isAgree = isAgree;
     }
 
-    public void updateAgreementCounts(long agreementCount, long disagreementCount) {
-    }
+
 }

--- a/src/main/java/likelion/underdog/songgotmae/domain/agreement/AgreementRepository.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/agreement/AgreementRepository.java
@@ -1,6 +1,13 @@
 package likelion.underdog.songgotmae.domain.agreement;
 
+import likelion.underdog.songgotmae.domain.member.Member;
+import likelion.underdog.songgotmae.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AgreementRepository extends JpaRepository<Agreement, Long> {
+    long countByPostAndIsAgree(Post post, boolean isAgree);
+
+    Optional<Agreement> findByMemberAndPost(Member member, Post post);
 }

--- a/src/main/java/likelion/underdog/songgotmae/domain/agreement/AgreementRepository.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/agreement/AgreementRepository.java
@@ -4,10 +4,13 @@ import likelion.underdog.songgotmae.domain.member.Member;
 import likelion.underdog.songgotmae.domain.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AgreementRepository extends JpaRepository<Agreement, Long> {
     long countByPostAndIsAgree(Post post, boolean isAgree);
 
     Optional<Agreement> findByMemberAndPost(Member member, Post post);
+
+    List<Agreement> findByPost(Post post);
 }

--- a/src/main/java/likelion/underdog/songgotmae/domain/agreement/AgreementServiceImpl.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/agreement/AgreementServiceImpl.java
@@ -41,8 +41,6 @@ public class AgreementServiceImpl implements AgreementService {
                 .build();
         Agreement saveAgreement = agreementRepository.save(newAgreement);
 
-        updateAgreementCounts(findPost);
-
         return AgreementDto.Response.builder()
                 .agreementId(saveAgreement.getId())
                 .message("게시글에 대한 반응이 정상적으로 반영되었습니다.")
@@ -50,15 +48,11 @@ public class AgreementServiceImpl implements AgreementService {
 
     }
 
-    private void updateAgreementCounts(Post post) {
-        List<Agreement> agreements = agreementRepository.findByPost(post);
+    private void updateAgreementCountsForPost(Post post) {
+        long agreementCount = agreementRepository.countByPostAndIsAgree(post, true);
+        long disagreementCount = agreementRepository.countByPostAndIsAgree(post, false);
 
-        long agreementCount = agreements.stream().filter(agreement -> agreement.getIsAgree()).count();
-        long disagreementCount = agreements.size() - agreementCount;
-
-        for (Agreement agreement : agreements) {
-            agreement.updateAgreementCounts(agreementCount, disagreementCount);
-        }
+        post.updateAgreementCounts(agreementCount, disagreementCount);
     }
 
     @Override

--- a/src/main/java/likelion/underdog/songgotmae/domain/agreement/AgreementServiceImpl.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/agreement/AgreementServiceImpl.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -40,14 +41,24 @@ public class AgreementServiceImpl implements AgreementService {
                 .build();
         Agreement saveAgreement = agreementRepository.save(newAgreement);
 
-        long agreementCount = agreementRepository.countByPostAndIsAgree(findPost, true);
-        long disagreementCount = agreementRepository.countByPostAndIsAgree(findPost, false);
-
+        updateAgreementCounts(findPost);
 
         return AgreementDto.Response.builder()
                 .agreementId(saveAgreement.getId())
                 .message("게시글에 대한 반응이 정상적으로 반영되었습니다.")
                 .build();
+
+    }
+
+    private void updateAgreementCounts(Post post) {
+        List<Agreement> agreements = agreementRepository.findByPost(post);
+
+        long agreementCount = agreements.stream().filter(agreement -> agreement.getIsAgree()).count();
+        long disagreementCount = agreements.size() - agreementCount;
+
+        for (Agreement agreement : agreements) {
+            agreement.updateAgreementCounts(agreementCount, disagreementCount);
+        }
     }
 
     @Override
@@ -58,6 +69,4 @@ public class AgreementServiceImpl implements AgreementService {
                 .build();
         return response;
     }
-
-
 }

--- a/src/main/java/likelion/underdog/songgotmae/domain/post/Post.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/post/Post.java
@@ -37,7 +37,13 @@ public class Post {
     @Comment("운영자가 검열했는지 여부 ~ null : in queue, true : 찬성, false : 반대")
     private Boolean isApproved;
 
+    private Long agreementCount;
+    private Long disagreementCount;
 
+    public void updateAgreementCounts(long agreementCount, long disagreementCount) {
+        this.agreementCount = agreementCount;
+        this.disagreementCount = disagreementCount;
+    }
 
     @CreatedDate
     @Column(nullable = false)
@@ -59,6 +65,8 @@ public class Post {
         this.title = title;
         this.content = content;
         this.isApproved = isApproved;
+        this.agreementCount = 0L; //초기값 0 설정
+        this.disagreementCount = 0L; //초기값 0 설정
     }
 }
 

--- a/src/main/java/likelion/underdog/songgotmae/domain/post/Post.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/post/Post.java
@@ -11,6 +11,8 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -34,6 +36,8 @@ public class Post {
 
     @Comment("운영자가 검열했는지 여부 ~ null : in queue, true : 찬성, false : 반대")
     private Boolean isApproved;
+
+
 
     @CreatedDate
     @Column(nullable = false)

--- a/src/main/java/likelion/underdog/songgotmae/domain/post/PostServiceImpl.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/post/PostServiceImpl.java
@@ -100,4 +100,6 @@ public class PostServiceImpl implements PostService {
                 .map(p -> PostDto.FindResponseDto.builder().post(p).build())
                 .toList();
     }
+
+
 }

--- a/src/main/java/likelion/underdog/songgotmae/domain/post/PostServiceImpl.java
+++ b/src/main/java/likelion/underdog/songgotmae/domain/post/PostServiceImpl.java
@@ -113,14 +113,11 @@ public class PostServiceImpl implements PostService {
     private void updateAgreementCountsForPost(Post post) {
         List<Agreement> agreements = agreementRepository.findByPost(post);
 
-        long agreementCount = agreements.stream().filter(agreement -> agreement.getIsAgree()).count();
+        long agreementCount = agreements.stream().filter(Agreement::getIsAgree).count();
         long disagreementCount = agreements.size() - agreementCount;
 
         post.updateAgreementCounts(agreementCount, disagreementCount);
 
-        for (Agreement agreement : agreements) {
-            agreement.updateAgreementCounts(agreementCount, disagreementCount);
-        }
     }
 
 

--- a/src/main/java/likelion/underdog/songgotmae/web/PostController.java
+++ b/src/main/java/likelion/underdog/songgotmae/web/PostController.java
@@ -83,4 +83,6 @@ public class PostController {
                 .body(memberPosts);
     }
 
+
+
 }


### PR DESCRIPTION
### 작업내용
기존 agreementServiceImpl 코드를 수정해 isAgree의 참 거짓으로 찬성반대를 나타내도록 수정.
### 이슈
count해서 누적되는 개수를 나타내려 했으나 실패, count부분의 코드가 작동하지를 않는다...
내가 작업해야하는 api가 이것이 맞는지 다 하고 의문이 들기 시작했다. 새로 반대하는 api를 만들어야 했던것같기도 아닌것같기도
브랜치 명도 작업내용과 안 맞는 reject를 사용했다ㅠㅠ
